### PR TITLE
Fixed core count

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "job-dispatcher" %}
-{% set version = "0.1.4" %}
+{% set version = "0.1.5" %}
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name="job-dispatcher",
-    version="0.1.4",
+    version="0.1.5",
     description="",
     long_description="",
     packages=["jobdispatcher"],


### PR DESCRIPTION
Now counter takes into account the single core main process.

Also, kill Syncmanager process at the end of the job to avoid counting issues in the interactive python.